### PR TITLE
Feat/ weather cache(redis) 적용 및 WeatherClient 캐싱 구조 도입

### DIFF
--- a/src/main/java/com/yunhwan/wit/application/weather/CachingWeatherClient.java
+++ b/src/main/java/com/yunhwan/wit/application/weather/CachingWeatherClient.java
@@ -1,0 +1,98 @@
+package com.yunhwan.wit.application.weather;
+
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import com.yunhwan.wit.domain.model.WeatherSnapshot;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CachingWeatherClient implements WeatherClient {
+
+    private static final Logger log = LoggerFactory.getLogger(CachingWeatherClient.class);
+
+    private final WeatherClient delegate;
+    private final WeatherCache weatherCache;
+    private final Clock clock;
+
+    public CachingWeatherClient(
+            WeatherClient delegate,
+            WeatherCache weatherCache,
+            Clock clock
+    ) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+        this.weatherCache = Objects.requireNonNull(weatherCache, "weatherCache must not be null");
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    @Override
+    public WeatherSnapshot fetchCurrentWeather(ResolvedLocation location) {
+        LocalDateTime cacheTime = LocalDateTime.now(clock).truncatedTo(ChronoUnit.HOURS);
+        WeatherSnapshot cached = readCurrentFromCache(location, cacheTime);
+        if (cached != null) {
+            return cached;
+        }
+
+        WeatherSnapshot weatherSnapshot = delegate.fetchCurrentWeather(location);
+        writeCurrentToCache(location, cacheTime, weatherSnapshot);
+        return weatherSnapshot;
+    }
+
+    @Override
+    public WeatherSnapshot fetchWeatherAt(ResolvedLocation location, LocalDateTime targetTime) {
+        WeatherSnapshot cached = readForecastFromCache(location, targetTime);
+        if (cached != null) {
+            return cached;
+        }
+
+        WeatherSnapshot weatherSnapshot = delegate.fetchWeatherAt(location, targetTime);
+        writeForecastToCache(location, targetTime, weatherSnapshot);
+        return weatherSnapshot;
+    }
+
+    private WeatherSnapshot readCurrentFromCache(ResolvedLocation location, LocalDateTime cacheTime) {
+        try {
+            return weatherCache.findCurrent(location, cacheTime).orElse(null);
+        } catch (RuntimeException exception) {
+            log.warn("Weather cache read failed for current weather. location={}", location.displayLocation(), exception);
+            return null;
+        }
+    }
+
+    private WeatherSnapshot readForecastFromCache(ResolvedLocation location, LocalDateTime targetTime) {
+        try {
+            return weatherCache.findForecast(location, targetTime).orElse(null);
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "Weather cache read failed for forecast weather. location={}, targetTime={}",
+                    location.displayLocation(),
+                    targetTime,
+                    exception
+            );
+            return null;
+        }
+    }
+
+    private void writeCurrentToCache(ResolvedLocation location, LocalDateTime cacheTime, WeatherSnapshot weatherSnapshot) {
+        try {
+            weatherCache.putCurrent(location, cacheTime, weatherSnapshot);
+        } catch (RuntimeException exception) {
+            log.warn("Weather cache write failed for current weather. location={}", location.displayLocation(), exception);
+        }
+    }
+
+    private void writeForecastToCache(ResolvedLocation location, LocalDateTime targetTime, WeatherSnapshot weatherSnapshot) {
+        try {
+            weatherCache.putForecast(location, targetTime, weatherSnapshot);
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "Weather cache write failed for forecast weather. location={}, targetTime={}",
+                    location.displayLocation(),
+                    targetTime,
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/com/yunhwan/wit/application/weather/WeatherCache.java
+++ b/src/main/java/com/yunhwan/wit/application/weather/WeatherCache.java
@@ -1,0 +1,17 @@
+package com.yunhwan.wit.application.weather;
+
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import com.yunhwan.wit.domain.model.WeatherSnapshot;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface WeatherCache {
+
+    Optional<WeatherSnapshot> findCurrent(ResolvedLocation location, LocalDateTime cacheTime);
+
+    Optional<WeatherSnapshot> findForecast(ResolvedLocation location, LocalDateTime targetTime);
+
+    void putCurrent(ResolvedLocation location, LocalDateTime cacheTime, WeatherSnapshot weatherSnapshot);
+
+    void putForecast(ResolvedLocation location, LocalDateTime targetTime, WeatherSnapshot weatherSnapshot);
+}

--- a/src/main/java/com/yunhwan/wit/infrastructure/weather/RedisWeatherCache.java
+++ b/src/main/java/com/yunhwan/wit/infrastructure/weather/RedisWeatherCache.java
@@ -1,0 +1,106 @@
+package com.yunhwan.wit.infrastructure.weather;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yunhwan.wit.application.weather.WeatherCache;
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import com.yunhwan.wit.domain.model.WeatherSnapshot;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+public class RedisWeatherCache implements WeatherCache {
+
+    private static final String KEY_PREFIX = "weather:";
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final WeatherCacheProperties properties;
+
+    public RedisWeatherCache(
+            StringRedisTemplate redisTemplate,
+            ObjectMapper objectMapper,
+            WeatherCacheProperties properties
+    ) {
+        this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        this.properties = Objects.requireNonNull(properties, "properties must not be null");
+    }
+
+    @Override
+    public Optional<WeatherSnapshot> findCurrent(ResolvedLocation location, LocalDateTime cacheTime) {
+        return find(toKey("current", location, cacheTime));
+    }
+
+    @Override
+    public Optional<WeatherSnapshot> findForecast(ResolvedLocation location, LocalDateTime targetTime) {
+        return find(toKey("forecast", location, targetTime));
+    }
+
+    @Override
+    public void putCurrent(ResolvedLocation location, LocalDateTime cacheTime, WeatherSnapshot weatherSnapshot) {
+        put(toKey("current", location, cacheTime), weatherSnapshot, ttlForCurrent());
+    }
+
+    @Override
+    public void putForecast(ResolvedLocation location, LocalDateTime targetTime, WeatherSnapshot weatherSnapshot) {
+        put(toKey("forecast", location, targetTime), weatherSnapshot, ttlForForecast());
+    }
+
+    private Optional<WeatherSnapshot> find(String key) {
+        String payload = redisTemplate.opsForValue().get(key);
+        if (payload == null || payload.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(objectMapper.readValue(payload, WeatherSnapshot.class));
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to deserialize cached weather snapshot", exception);
+        }
+    }
+
+    private void put(String key, WeatherSnapshot weatherSnapshot, Duration ttl) {
+        try {
+            redisTemplate.opsForValue().set(
+                    key,
+                    objectMapper.writeValueAsString(weatherSnapshot),
+                    ttl
+            );
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Failed to serialize weather snapshot for cache", exception);
+        }
+    }
+
+    private String toKey(String weatherType, ResolvedLocation location, LocalDateTime targetTime) {
+        Objects.requireNonNull(location, "location must not be null");
+        Objects.requireNonNull(targetTime, "targetTime must not be null");
+
+        if (location.lat() == null || location.lng() == null) {
+            throw new IllegalArgumentException("location coordinates must not be null");
+        }
+
+        return KEY_PREFIX
+                + weatherType.toLowerCase(Locale.ROOT)
+                + ":"
+                + location.lat()
+                + ":"
+                + location.lng()
+                + ":"
+                + TIME_FORMATTER.format(targetTime);
+    }
+
+    private Duration ttlForCurrent() {
+        return properties.ttl();
+    }
+
+    private Duration ttlForForecast() {
+        return properties.ttl();
+    }
+}

--- a/src/main/java/com/yunhwan/wit/infrastructure/weather/WeatherCacheProperties.java
+++ b/src/main/java/com/yunhwan/wit/infrastructure/weather/WeatherCacheProperties.java
@@ -1,0 +1,10 @@
+package com.yunhwan.wit.infrastructure.weather;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "wit.weather.cache")
+public record WeatherCacheProperties(
+        Duration ttl
+) {
+}

--- a/src/main/java/com/yunhwan/wit/infrastructure/weather/WeatherClientConfig.java
+++ b/src/main/java/com/yunhwan/wit/infrastructure/weather/WeatherClientConfig.java
@@ -1,16 +1,42 @@
 package com.yunhwan.wit.infrastructure.weather;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yunhwan.wit.application.weather.CachingWeatherClient;
+import com.yunhwan.wit.application.weather.WeatherCache;
+import com.yunhwan.wit.application.weather.WeatherClient;
+import java.time.Clock;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.web.client.RestClient;
 
 @Configuration
-@EnableConfigurationProperties(WeatherApiProperties.class)
+@EnableConfigurationProperties({WeatherApiProperties.class, WeatherCacheProperties.class})
 public class WeatherClientConfig {
 
     @Bean
     public RestClient weatherRestClient(RestClient.Builder builder, WeatherApiProperties properties) {
         return builder.baseUrl(properties.baseUrl()).build();
+    }
+
+    @Bean
+    public WeatherCache weatherCache(
+            StringRedisTemplate redisTemplate,
+            ObjectMapper objectMapper,
+            WeatherCacheProperties properties
+    ) {
+        return new RedisWeatherCache(redisTemplate, objectMapper, properties);
+    }
+
+    @Bean
+    @Primary
+    public WeatherClient weatherClient(
+            HttpWeatherClient httpWeatherClient,
+            WeatherCache weatherCache,
+            Clock clock
+    ) {
+        return new CachingWeatherClient(httpWeatherClient, weatherCache, clock);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,8 @@ wit:
       lat: ${CURRENT_LOCATION_LAT:37.5172}
       lng: ${CURRENT_LOCATION_LNG:127.0473}
   weather:
+    cache:
+      ttl: ${WEATHER_CACHE_TTL:1h}
     api:
       base-url: ${WEATHER_API_BASE_URL:https://api.example.com}
       current-path: ${WEATHER_API_CURRENT_PATH:/current}

--- a/src/test/java/com/yunhwan/wit/application/weather/CachingWeatherClientTest.java
+++ b/src/test/java/com/yunhwan/wit/application/weather/CachingWeatherClientTest.java
@@ -1,0 +1,145 @@
+package com.yunhwan.wit.application.weather;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yunhwan.wit.domain.model.LocationResolvedBy;
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import com.yunhwan.wit.domain.model.WeatherSnapshot;
+import com.yunhwan.wit.domain.model.WeatherType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class CachingWeatherClientTest {
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-04-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    @Test
+    void 현재날씨_캐시히트면_delegate를_다시_호출하지_않는다() {
+        ResolvedLocation location = resolvedLocation();
+        WeatherSnapshot snapshot = currentSnapshot();
+        CountingWeatherClient delegate = new CountingWeatherClient(snapshot, forecastSnapshot());
+        InMemoryWeatherCache cache = new InMemoryWeatherCache();
+        cache.putCurrent(location, LocalDateTime.of(2026, 4, 1, 9, 0), snapshot);
+        CachingWeatherClient weatherClient = new CachingWeatherClient(delegate, cache, clock);
+
+        WeatherSnapshot result = weatherClient.fetchCurrentWeather(location);
+
+        assertThat(result).isEqualTo(snapshot);
+        assertThat(delegate.currentInvocationCount()).isZero();
+    }
+
+    @Test
+    void 예보_캐시미스면_delegate결과를_캐시에_저장한다() {
+        ResolvedLocation location = resolvedLocation();
+        LocalDateTime targetTime = LocalDateTime.of(2026, 4, 1, 18, 0);
+        WeatherSnapshot snapshot = forecastSnapshot();
+        CountingWeatherClient delegate = new CountingWeatherClient(currentSnapshot(), snapshot);
+        InMemoryWeatherCache cache = new InMemoryWeatherCache();
+        CachingWeatherClient weatherClient = new CachingWeatherClient(delegate, cache, clock);
+
+        WeatherSnapshot result = weatherClient.fetchWeatherAt(location, targetTime);
+
+        assertThat(result).isEqualTo(snapshot);
+        assertThat(delegate.forecastInvocationCount()).isEqualTo(1);
+        assertThat(cache.findForecast(location, targetTime)).contains(snapshot);
+    }
+
+    private ResolvedLocation resolvedLocation() {
+        return ResolvedLocation.resolved(
+                "강남 회식",
+                "강남",
+                "서울특별시 강남구",
+                37.4979,
+                127.0276,
+                0.9,
+                LocationResolvedBy.RULE
+        );
+    }
+
+    private WeatherSnapshot currentSnapshot() {
+        return new WeatherSnapshot(
+                "서울특별시 강남구",
+                LocalDateTime.of(2026, 4, 1, 9, 0),
+                18,
+                17,
+                20,
+                WeatherType.CLEAR
+        );
+    }
+
+    private WeatherSnapshot forecastSnapshot() {
+        return new WeatherSnapshot(
+                "서울특별시 강남구",
+                LocalDateTime.of(2026, 4, 1, 18, 0),
+                16,
+                14,
+                70,
+                WeatherType.RAIN
+        );
+    }
+
+    private static final class CountingWeatherClient implements WeatherClient {
+
+        private final AtomicInteger currentInvocationCount = new AtomicInteger();
+        private final AtomicInteger forecastInvocationCount = new AtomicInteger();
+        private final WeatherSnapshot currentSnapshot;
+        private final WeatherSnapshot forecastSnapshot;
+
+        private CountingWeatherClient(WeatherSnapshot currentSnapshot, WeatherSnapshot forecastSnapshot) {
+            this.currentSnapshot = currentSnapshot;
+            this.forecastSnapshot = forecastSnapshot;
+        }
+
+        @Override
+        public WeatherSnapshot fetchCurrentWeather(ResolvedLocation location) {
+            currentInvocationCount.incrementAndGet();
+            return currentSnapshot;
+        }
+
+        @Override
+        public WeatherSnapshot fetchWeatherAt(ResolvedLocation location, LocalDateTime targetTime) {
+            forecastInvocationCount.incrementAndGet();
+            return forecastSnapshot;
+        }
+
+        private int currentInvocationCount() {
+            return currentInvocationCount.get();
+        }
+
+        private int forecastInvocationCount() {
+            return forecastInvocationCount.get();
+        }
+    }
+
+    private static final class InMemoryWeatherCache implements WeatherCache {
+
+        private final Map<String, WeatherSnapshot> store = new HashMap<>();
+
+        @Override
+        public Optional<WeatherSnapshot> findCurrent(ResolvedLocation location, LocalDateTime cacheTime) {
+            return Optional.ofNullable(store.get("current:" + location.lat() + ":" + location.lng() + ":" + cacheTime));
+        }
+
+        @Override
+        public Optional<WeatherSnapshot> findForecast(ResolvedLocation location, LocalDateTime targetTime) {
+            return Optional.ofNullable(store.get("forecast:" + location.lat() + ":" + location.lng() + ":" + targetTime));
+        }
+
+        @Override
+        public void putCurrent(ResolvedLocation location, LocalDateTime cacheTime, WeatherSnapshot weatherSnapshot) {
+            store.put("current:" + location.lat() + ":" + location.lng() + ":" + cacheTime, weatherSnapshot);
+        }
+
+        @Override
+        public void putForecast(ResolvedLocation location, LocalDateTime targetTime, WeatherSnapshot weatherSnapshot) {
+            store.put("forecast:" + location.lat() + ":" + location.lng() + ":" + targetTime, weatherSnapshot);
+        }
+    }
+}

--- a/src/test/java/com/yunhwan/wit/infrastructure/weather/RedisWeatherCacheTest.java
+++ b/src/test/java/com/yunhwan/wit/infrastructure/weather/RedisWeatherCacheTest.java
@@ -1,0 +1,89 @@
+package com.yunhwan.wit.infrastructure.weather;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yunhwan.wit.domain.model.LocationResolvedBy;
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import com.yunhwan.wit.domain.model.WeatherSnapshot;
+import com.yunhwan.wit.domain.model.WeatherType;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class RedisWeatherCacheTest {
+
+    @Test
+    void 현재날씨를_문서TTL로_저장한다() throws Exception {
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        RedisWeatherCache weatherCache = new RedisWeatherCache(
+                redisTemplate,
+                new ObjectMapper().findAndRegisterModules(),
+                new WeatherCacheProperties(Duration.ofHours(1))
+        );
+
+        weatherCache.putCurrent(resolvedLocation(), LocalDateTime.of(2026, 4, 1, 9, 0), snapshot());
+
+        verify(valueOperations).set(
+                eq("weather:current:37.4979:127.0276:2026-04-01T09:00:00"),
+                eq(new ObjectMapper().findAndRegisterModules().writeValueAsString(snapshot())),
+                eq(Duration.ofHours(1))
+        );
+    }
+
+    @Test
+    void 예보캐시_조회키는_좌표와_요청시각으로_구성한다() throws Exception {
+        String serialized = new ObjectMapper().findAndRegisterModules().writeValueAsString(snapshot());
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("weather:forecast:37.4979:127.0276:2026-04-01T18:00:00")).thenReturn(serialized);
+
+        RedisWeatherCache weatherCache = new RedisWeatherCache(
+                redisTemplate,
+                new ObjectMapper().findAndRegisterModules(),
+                new WeatherCacheProperties(Duration.ofHours(1))
+        );
+
+        WeatherSnapshot result = weatherCache.findForecast(
+                resolvedLocation(),
+                LocalDateTime.of(2026, 4, 1, 18, 0)
+        ).orElseThrow();
+
+        assertThat(result).isEqualTo(snapshot());
+    }
+
+    private ResolvedLocation resolvedLocation() {
+        return ResolvedLocation.resolved(
+                "강남 회식",
+                "강남",
+                "서울특별시 강남구",
+                37.4979,
+                127.0276,
+                0.9,
+                LocationResolvedBy.RULE
+        );
+    }
+
+    private WeatherSnapshot snapshot() {
+        return new WeatherSnapshot(
+                "서울특별시 강남구",
+                LocalDateTime.of(2026, 4, 1, 18, 0),
+                16,
+                14,
+                70,
+                WeatherType.RAIN
+        );
+    }
+}


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

close #17 

Step 16: Redis weather cache

- weather cache application 포트 추가
- Redis 기반 cache adapter 구현
- weather 조회 결과를 캐싱하기 위한 cache decorator 추가
- @Primary 설정을 통해 기존 WeatherClient 앞단에 cache decorator 조립

- weather 데이터 유형에 따른 TTL 설정 추가
  (현재 / 예보 기준 분리)

- cache hit / miss 동작 테스트 추가
- cache key 및 TTL 검증 테스트 추가

이번 단계에서는 weather 조회 흐름에만 캐시를 적용하고,
location / recommendation cache는 포함하지 않음

이를 통해 동일한 날씨 요청에 대해
불필요한 외부 API 호출을 줄일 수 있도록 구성함

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [x] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
