### PR TITLE
Feat/ API 응답 스펙 정리 및 Swagger 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/docs/api-spec-ko.md
+++ b/docs/api-spec-ko.md
@@ -1,0 +1,88 @@
+# API 응답 스펙
+
+최신 기준:
+
+- Swagger UI: `/swagger-ui/index.html`
+- OpenAPI JSON: `/v3/api-docs`
+
+## 1. 공통 원칙
+
+- 추천 성공 응답의 사용자용 핵심 필드는 `eventId`, `title`, `startAt`, `endAt`, `location`, `needUmbrella`, `recommendedOutfitText`, `summary`다.
+- `summary`는 현재 구현의 `OutfitDecision.aiSummary`를 외부 API 필드명으로 노출한 값이다.
+- `location`은 현재 구현의 해석 결과 표시 위치(`resolvedLocation.displayLocation`)다.
+- `locationFallbackApplied=true`면 일정 위치 해석에 실패해 현재 위치 기준으로 추천한 경우다.
+- `weatherFallbackApplied=true`면 날씨 조회 실패로 safe default 추천을 반환한 경우다.
+- `weatherSource=CACHE`면 실시간 대신 최신 캐시 날씨를 사용한 경우다.
+- `fallbackNotice`는 fallback 의미를 바로 이해할 수 있게 추가한 사용자용 안내 문구다.
+
+## 2. 엔드포인트
+
+### GET `/api/integrations/google/login-url`
+
+- 응답: `loginUrl`
+
+### POST `/api/integrations/google/callback`
+
+- 요청 본문:
+  - `code`
+  - `state`
+- 응답:
+  - `connected`
+  - `email`
+  - `calendarEventCount`
+
+### GET `/api/recommendations/home`
+
+- 응답: `recommendations[]`
+- 각 항목 공통 핵심 필드:
+  - `eventId`
+  - `title`
+  - `startAt`
+  - `endAt`
+  - `location`
+  - `needUmbrella`
+  - `recommendedOutfitText`
+  - `summary`
+- 상세 보조 필드:
+  - `locationFallbackApplied`
+  - `weatherFallbackApplied`
+  - `weatherSource`
+  - `fallbackNotice`
+  - `rawLocation`
+  - `locationResolution`
+  - `umbrellaReason`
+  - `outfitReason`
+  - `temperatureGap`
+  - `weatherChangeSummary`
+  - `currentWeather`
+  - `startWeather`
+  - `endWeather`
+
+### GET `/api/recommendations/events/{eventId}`
+
+- 응답: 홈 항목과 동일한 단건 상세 구조
+- `eventId`가 향후 7일/최대 3건 조회 결과에 없으면 `404 RECOMMENDATION_404`
+
+## 3. 오류 응답
+
+공통 오류 구조:
+
+- `code`
+- `message`
+- `errors`
+
+대표 코드:
+
+- `COMMON_400`: 잘못된 요청
+- `RECOMMENDATION_404`: 추천 대상 일정 없음
+- `GOOGLE_401`: Google 재연동 필요
+- `GOOGLE_503`: Google 연동 장애
+- `COMMON_500`: 서버 내부 오류
+
+## 4. 현재 구현 기준 주의사항
+
+- `summary`는 AI summary 실패 시 deterministic fallback 문장으로 대체될 수 있다.
+- `weatherFallbackApplied=true`면 `currentWeather`, `startWeather`, `endWeather`는 `null`이다.
+- `weatherSource`는 `NORMAL`, `CACHE`, `SAFE_DEFAULT` 중 하나다.
+- `POST /api/integrations/google/callback`이 iOS용 기준 엔드포인트다.
+- 기존 GET callback도 호환용으로 유지되지만, 신규 클라이언트 계약은 POST 기준으로 본다.

--- a/src/main/java/com/yunhwan/wit/application/exception/ErrorCode.java
+++ b/src/main/java/com/yunhwan/wit/application/exception/ErrorCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+    RECOMMENDATION_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "RECOMMENDATION_404", "추천 대상을 찾을 수 없습니다."),
     GOOGLE_REAUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "GOOGLE_401", "Google 재연동이 필요합니다."),
     GOOGLE_INTEGRATION_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "GOOGLE_503", "Google 연동 중 오류가 발생했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/yunhwan/wit/application/recommendation/RecommendationHomeService.java
+++ b/src/main/java/com/yunhwan/wit/application/recommendation/RecommendationHomeService.java
@@ -1,5 +1,7 @@
 package com.yunhwan.wit.application.recommendation;
 
+import com.yunhwan.wit.application.exception.ErrorCode;
+import com.yunhwan.wit.application.exception.WitException;
 import com.yunhwan.wit.application.google.GoogleIntegrationService;
 import com.yunhwan.wit.domain.model.CalendarEvent;
 import java.util.List;
@@ -37,6 +39,20 @@ public class RecommendationHomeService {
                 .map(this::recommendSafely)
                 .flatMap(Optional::stream)
                 .toList();
+    }
+
+    public RecommendationResult getEventRecommendation(String eventId) {
+        Objects.requireNonNull(eventId, "eventId must not be null");
+
+        CalendarEvent calendarEvent = googleIntegrationService.getUpcomingEvents().stream()
+                .filter(event -> eventId.equals(event.eventId()))
+                .findFirst()
+                .orElseThrow(() -> new WitException(
+                        ErrorCode.RECOMMENDATION_EVENT_NOT_FOUND,
+                        "eventId에 해당하는 추천 대상이 없습니다. eventId=" + eventId
+                ));
+
+        return recommendationService.recommend(calendarEvent);
     }
 
     private Optional<RecommendationResult> recommendSafely(CalendarEvent calendarEvent) {

--- a/src/main/java/com/yunhwan/wit/infrastructure/config/OpenApiConfig.java
+++ b/src/main/java/com/yunhwan/wit/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package com.yunhwan.wit.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI witOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Wit Backend API")
+                        .version("v1")
+                        .description("iOS 연동용 MVP API 스펙")
+                        .contact(new Contact().name("wit-backend")));
+    }
+}

--- a/src/main/java/com/yunhwan/wit/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/yunhwan/wit/infrastructure/config/SecurityConfig.java
@@ -16,10 +16,14 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.GET, "/api/integrations/google/login-url").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/integrations/google/callback").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/integrations/google/callback").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/recommendations/home").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/recommendations/events/*").permitAll()
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(withDefaults())

--- a/src/main/java/com/yunhwan/wit/presentation/api/ApiErrorResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/ApiErrorResponse.java
@@ -1,11 +1,16 @@
 package com.yunhwan.wit.presentation.api;
 
 import com.yunhwan.wit.application.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "공통 오류 응답")
 public record ApiErrorResponse(
+        @Schema(description = "오류 코드", example = "COMMON_400")
         String code,
+        @Schema(description = "오류 메시지", example = "잘못된 요청입니다.")
         String message,
+        @Schema(description = "필드 단위 검증 오류 목록")
         List<ValidationError> errors
 ) {
 
@@ -25,8 +30,11 @@ public record ApiErrorResponse(
         return new ApiErrorResponse(errorCode.getCode(), message, errors);
     }
 
+    @Schema(description = "필드 검증 오류")
     public record ValidationError(
+            @Schema(description = "오류 필드", example = "code")
             String field,
+            @Schema(description = "오류 메시지", example = "must not be blank")
             String message
     ) {
     }

--- a/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleCallbackRequest.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleCallbackRequest.java
@@ -1,0 +1,15 @@
+package com.yunhwan.wit.presentation.api.integration;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Google OAuth callback 요청")
+public record GoogleCallbackRequest(
+        @NotBlank
+        @Schema(description = "Google OAuth authorization code", example = "4/0AdQt8q...")
+        String code,
+        @NotBlank
+        @Schema(description = "OAuth state", example = "wit-google-state")
+        String state
+) {
+}

--- a/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleCallbackResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleCallbackResponse.java
@@ -1,8 +1,14 @@
 package com.yunhwan.wit.presentation.api.integration;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Google 연동 완료 응답")
 public record GoogleCallbackResponse(
+        @Schema(description = "연동 성공 여부", example = "true")
         boolean connected,
+        @Schema(description = "연동된 Google 계정 이메일", example = "user@wit.local")
         String email,
+        @Schema(description = "조회된 캘린더 이벤트 수", example = "3")
         int calendarEventCount
 ) {
 }

--- a/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleIntegrationController.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleIntegrationController.java
@@ -4,13 +4,24 @@ import com.yunhwan.wit.application.google.GoogleCallbackCommand;
 import com.yunhwan.wit.application.google.GoogleConnectionResult;
 import com.yunhwan.wit.application.google.GoogleIntegrationService;
 import com.yunhwan.wit.application.google.GoogleLoginUrlResult;
+import com.yunhwan.wit.presentation.api.ApiErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/integrations/google")
+@Tag(name = "Google Integration", description = "Google OAuth / Calendar 연동 API")
 public class GoogleIntegrationController {
 
     private final GoogleIntegrationService googleIntegrationService;
@@ -20,6 +31,11 @@ public class GoogleIntegrationController {
     }
 
     @GetMapping("/login-url")
+    @Operation(summary = "Google 로그인 URL 조회", description = "iOS가 Google OAuth 진입에 사용할 로그인 URL을 반환한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = GoogleLoginUrlResponse.class)))
+    })
     public GoogleLoginUrlResponse getLoginUrl() {
         GoogleLoginUrlResult result = googleIntegrationService.getLoginUrl();
         return new GoogleLoginUrlResponse(result.loginUrl());
@@ -30,7 +46,27 @@ public class GoogleIntegrationController {
             @RequestParam String code,
             @RequestParam String state
     ) {
-        GoogleConnectionResult result = googleIntegrationService.connect(new GoogleCallbackCommand(code, state));
+        return connect(new GoogleCallbackRequest(code, state));
+    }
+
+    @PostMapping("/callback")
+    @Operation(summary = "Google OAuth callback 처리", description = "iOS가 받은 authorization code/state를 서버에 전달해 Google 연동을 완료한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "연동 성공",
+                    content = @Content(schema = @Schema(implementation = GoogleCallbackResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Google 재연동 필요",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "503", description = "Google 연동 장애",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
+    public GoogleCallbackResponse connect(
+            @Valid @RequestBody GoogleCallbackRequest request
+    ) {
+        GoogleConnectionResult result = googleIntegrationService.connect(
+                new GoogleCallbackCommand(request.code(), request.state())
+        );
         return new GoogleCallbackResponse(
                 result.connected(),
                 result.googleIntegration().email(),

--- a/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleLoginUrlResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/integration/GoogleLoginUrlResponse.java
@@ -1,6 +1,10 @@
 package com.yunhwan.wit.presentation.api.integration;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Google 로그인 URL 응답")
 public record GoogleLoginUrlResponse(
+        @Schema(description = "Google OAuth 로그인 URL", example = "https://accounts.google.com/o/oauth2/v2/auth?client_id=...")
         String loginUrl
 ) {
 }

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/HomeRecommendationResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/HomeRecommendationResponse.java
@@ -1,117 +1,18 @@
 package com.yunhwan.wit.presentation.api.recommendation;
 
 import com.yunhwan.wit.application.recommendation.RecommendationResult;
-import com.yunhwan.wit.domain.model.OutfitDecision;
-import com.yunhwan.wit.domain.model.ResolvedLocation;
-import com.yunhwan.wit.domain.model.WeatherSnapshot;
-import java.time.LocalDateTime;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "홈 추천 목록 응답")
 public record HomeRecommendationResponse(
-        List<HomeRecommendationItemResponse> recommendations
+        @Schema(description = "추천 목록")
+        List<RecommendationResponse> recommendations
 ) {
 
     public static HomeRecommendationResponse from(List<RecommendationResult> results) {
         return new HomeRecommendationResponse(results.stream()
-                .map(HomeRecommendationItemResponse::from)
+                .map(RecommendationResponse::from)
                 .toList());
-    }
-
-    public record HomeRecommendationItemResponse(
-            String eventId,
-            String title,
-            String rawLocation,
-            LocationResponse resolvedLocation,
-            boolean weatherFallbackApplied,
-            boolean locationFallbackApplied,
-            String weatherSource,
-            boolean needUmbrella,
-            String recommendedOutfitText,
-            String aiSummary,
-            String umbrellaReason,
-            String outfitReason,
-            Integer temperatureGap,
-            String weatherChangeSummary,
-            WeatherSnapshotResponse currentWeather,
-            WeatherSnapshotResponse startWeather,
-            WeatherSnapshotResponse endWeather
-    ) {
-
-        private static HomeRecommendationItemResponse from(RecommendationResult result) {
-            OutfitDecision decision = result.outfitDecision();
-            return new HomeRecommendationItemResponse(
-                    result.calendarEvent().eventId(),
-                    result.calendarEvent().title(),
-                    result.calendarEvent().rawLocation(),
-                    LocationResponse.from(result.resolvedLocation()),
-                    result.weatherFallbackApplied(),
-                    result.locationFallbackApplied(),
-                    result.weatherSource().name(),
-                    decision.needUmbrella(),
-                    decision.recommendedOutfitText(),
-                    decision.aiSummary(),
-                    decision.umbrellaReason(),
-                    decision.outfitReason(),
-                    decision.temperatureGap(),
-                    decision.weatherChangeSummary(),
-                    WeatherSnapshotResponse.from(result.currentWeather()),
-                    WeatherSnapshotResponse.from(result.startWeather()),
-                    WeatherSnapshotResponse.from(result.endWeather())
-            );
-        }
-    }
-
-    public record LocationResponse(
-            String rawLocation,
-            String normalizedQuery,
-            String displayLocation,
-            Double lat,
-            Double lng,
-            Double confidence,
-            String status,
-            String resolvedBy
-    ) {
-
-        private static LocationResponse from(ResolvedLocation location) {
-            if (location == null) {
-                return null;
-            }
-
-            return new LocationResponse(
-                    location.rawLocation(),
-                    location.normalizedQuery(),
-                    location.displayLocation(),
-                    location.lat(),
-                    location.lng(),
-                    location.confidence(),
-                    location.status().name(),
-                    location.resolvedBy() == null ? null : location.resolvedBy().name()
-            );
-        }
-    }
-
-    public record WeatherSnapshotResponse(
-            String regionName,
-            LocalDateTime targetTime,
-            int temperature,
-            int feelsLike,
-            int precipitationProbability,
-            String weatherType
-    ) {
-
-        private static WeatherSnapshotResponse from(WeatherSnapshot weatherSnapshot) {
-            if (weatherSnapshot == null) {
-                return null;
-            }
-
-            return new WeatherSnapshotResponse(
-                    weatherSnapshot.regionName(),
-                    weatherSnapshot.targetTime(),
-                    weatherSnapshot.temperature(),
-                    weatherSnapshot.feelsLike(),
-                    weatherSnapshot.precipitationProbability(),
-                    weatherSnapshot.weatherType().name()
-            );
-        }
     }
 }

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationController.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationController.java
@@ -2,15 +2,24 @@ package com.yunhwan.wit.presentation.api.recommendation;
 
 import com.yunhwan.wit.application.recommendation.RecommendationHomeService;
 import com.yunhwan.wit.application.recommendation.RecommendationResult;
+import com.yunhwan.wit.presentation.api.ApiErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/recommendations")
+@Tag(name = "Recommendations", description = "추천 조회 API")
 public class RecommendationController {
 
     private static final Logger log = LoggerFactory.getLogger(RecommendationController.class);
@@ -22,11 +31,41 @@ public class RecommendationController {
     }
 
     @GetMapping("/home")
+    @Operation(summary = "홈 추천 조회", description = "향후 일정 최대 3건에 대한 추천 목록을 반환한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = HomeRecommendationResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Google 재연동 필요",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "503", description = "Google 연동 장애",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
     public HomeRecommendationResponse getHomeRecommendations() {
         log.info("[RecommendationDebug] home request start");
         List<RecommendationResult> results = recommendationHomeService.getHomeRecommendations();
         HomeRecommendationResponse response = HomeRecommendationResponse.from(results);
         log.info("[RecommendationDebug] home request end. recommendationCount={}", results.size());
+        return response;
+    }
+
+    @GetMapping("/events/{eventId}")
+    @Operation(summary = "이벤트 상세 추천 조회", description = "지정한 eventId의 추천 상세를 반환한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = RecommendationResponse.class))),
+            @ApiResponse(responseCode = "404", description = "추천 대상 일정 없음",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Google 재연동 필요",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "503", description = "Google 연동 장애",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
+    public RecommendationResponse getEventRecommendation(@PathVariable String eventId) {
+        log.info("[RecommendationDebug] event detail request start. eventId={}", eventId);
+        RecommendationResponse response = RecommendationResponse.from(
+                recommendationHomeService.getEventRecommendation(eventId)
+        );
+        log.info("[RecommendationDebug] event detail request end. eventId={}", eventId);
         return response;
     }
 }

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationResponse.java
@@ -1,0 +1,164 @@
+package com.yunhwan.wit.presentation.api.recommendation;
+
+import com.yunhwan.wit.application.recommendation.RecommendationResult;
+import com.yunhwan.wit.domain.model.OutfitDecision;
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import com.yunhwan.wit.domain.model.WeatherSnapshot;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "추천 응답")
+public record RecommendationResponse(
+        @Schema(description = "일정 ID", example = "event-1")
+        String eventId,
+        @Schema(description = "일정 제목", example = "강남 회식")
+        String title,
+        @Schema(description = "일정 시작 시각", example = "2026-04-07T18:00:00")
+        LocalDateTime startAt,
+        @Schema(description = "일정 종료 시각", example = "2026-04-07T21:00:00")
+        LocalDateTime endAt,
+        @Schema(description = "표시용 위치", example = "서울특별시 강남구 테헤란로 1")
+        String location,
+        @Schema(description = "우산 필요 여부", example = "true")
+        boolean needUmbrella,
+        @Schema(description = "추천 옷차림 문구", example = "긴팔 + 가벼운 겉옷")
+        String recommendedOutfitText,
+        @Schema(description = "최종 요약 문구", example = "종료 시점 비 예보가 있어 우산과 긴팔 + 가벼운 겉옷이 필요합니다.")
+        String summary,
+        @Schema(description = "위치 fallback 적용 여부", example = "false")
+        boolean locationFallbackApplied,
+        @Schema(description = "날씨 fallback 적용 여부", example = "false")
+        boolean weatherFallbackApplied,
+        @Schema(description = "날씨 데이터 출처", example = "NORMAL", allowableValues = {"NORMAL", "CACHE", "SAFE_DEFAULT"})
+        String weatherSource,
+        @Schema(description = "fallback 안내 문구", example = "실시간 날씨 대신 최신 캐시 데이터를 사용했습니다.", nullable = true)
+        String fallbackNotice,
+        @Schema(description = "원본 위치 문자열", example = "강남 목구멍", nullable = true)
+        String rawLocation,
+        @Schema(description = "위치 해석 상세")
+        LocationResolutionResponse locationResolution,
+        @Schema(description = "우산 판단 이유", example = "종료 시점 비 예보가 있어 우산이 필요합니다.", nullable = true)
+        String umbrellaReason,
+        @Schema(description = "옷차림 판단 이유", example = "종료 시점 체감온도 기준으로 긴팔 + 가벼운 겉옷을 추천합니다.", nullable = true)
+        String outfitReason,
+        @Schema(description = "현재 대비 체감온도 차이", example = "-6", nullable = true)
+        Integer temperatureGap,
+        @Schema(description = "날씨 변화 요약", example = "현재보다 종료 시점이 더 쌀쌀합니다.", nullable = true)
+        String weatherChangeSummary,
+        @Schema(description = "현재 시점 날씨", nullable = true)
+        WeatherSnapshotResponse currentWeather,
+        @Schema(description = "일정 시작 시점 날씨", nullable = true)
+        WeatherSnapshotResponse startWeather,
+        @Schema(description = "일정 종료 시점 날씨", nullable = true)
+        WeatherSnapshotResponse endWeather
+) {
+
+    public static RecommendationResponse from(RecommendationResult result) {
+        OutfitDecision decision = result.outfitDecision();
+
+        return new RecommendationResponse(
+                result.calendarEvent().eventId(),
+                result.calendarEvent().title(),
+                result.calendarEvent().startAt(),
+                result.calendarEvent().endAt(),
+                result.resolvedLocation() == null ? null : result.resolvedLocation().displayLocation(),
+                decision.needUmbrella(),
+                decision.recommendedOutfitText(),
+                decision.aiSummary(),
+                result.locationFallbackApplied(),
+                result.weatherFallbackApplied(),
+                result.weatherSource().name(),
+                fallbackNotice(result),
+                result.calendarEvent().rawLocation(),
+                LocationResolutionResponse.from(result.resolvedLocation()),
+                decision.umbrellaReason(),
+                decision.outfitReason(),
+                decision.temperatureGap(),
+                decision.weatherChangeSummary(),
+                WeatherSnapshotResponse.from(result.currentWeather()),
+                WeatherSnapshotResponse.from(result.startWeather()),
+                WeatherSnapshotResponse.from(result.endWeather())
+        );
+    }
+
+    private static String fallbackNotice(RecommendationResult result) {
+        if (result.weatherFallbackApplied()) {
+            return "날씨 조회 실패로 안전 기본 추천을 반환했습니다.";
+        }
+        if ("CACHE".equals(result.weatherSource().name())) {
+            return "실시간 날씨 대신 최신 캐시 데이터를 사용했습니다.";
+        }
+        if (result.locationFallbackApplied()) {
+            return "일정 위치 해석에 실패해 현재 위치 기준으로 추천했습니다.";
+        }
+        return null;
+    }
+
+    @Schema(description = "위치 해석 상세")
+    public record LocationResolutionResponse(
+            @Schema(description = "원본 위치 문자열", example = "강남 목구멍", nullable = true)
+            String rawLocation,
+            @Schema(description = "정규화 질의", example = "목구멍 강남점", nullable = true)
+            String normalizedQuery,
+            @Schema(description = "표시용 위치", example = "서울특별시 강남구 테헤란로 1", nullable = true)
+            String displayLocation,
+            @Schema(description = "위도", example = "37.5001", nullable = true)
+            Double lat,
+            @Schema(description = "경도", example = "127.0362", nullable = true)
+            Double lng,
+            @Schema(description = "신뢰도", example = "0.85", nullable = true)
+            Double confidence,
+            @Schema(description = "해석 상태", example = "RESOLVED", allowableValues = {"RESOLVED", "APPROXIMATED", "FAILED"})
+            String status,
+            @Schema(description = "해석 출처", example = "GOOGLE_PLACES", nullable = true)
+            String resolvedBy
+    ) {
+        private static LocationResolutionResponse from(ResolvedLocation location) {
+            if (location == null) {
+                return null;
+            }
+
+            return new LocationResolutionResponse(
+                    location.rawLocation(),
+                    location.normalizedQuery(),
+                    location.displayLocation(),
+                    location.lat(),
+                    location.lng(),
+                    location.confidence(),
+                    location.status().name(),
+                    location.resolvedBy() == null ? null : location.resolvedBy().name()
+            );
+        }
+    }
+
+    @Schema(description = "날씨 스냅샷")
+    public record WeatherSnapshotResponse(
+            @Schema(description = "지역명", example = "서울특별시 강남구 테헤란로 1")
+            String regionName,
+            @Schema(description = "대상 시각", example = "2026-04-07T21:00:00")
+            LocalDateTime targetTime,
+            @Schema(description = "기온", example = "16")
+            int temperature,
+            @Schema(description = "체감온도", example = "14")
+            int feelsLike,
+            @Schema(description = "강수 확률", example = "70")
+            int precipitationProbability,
+            @Schema(description = "날씨 타입", example = "RAIN")
+            String weatherType
+    ) {
+        private static WeatherSnapshotResponse from(WeatherSnapshot weatherSnapshot) {
+            if (weatherSnapshot == null) {
+                return null;
+            }
+
+            return new WeatherSnapshotResponse(
+                    weatherSnapshot.regionName(),
+                    weatherSnapshot.targetTime(),
+                    weatherSnapshot.temperature(),
+                    weatherSnapshot.feelsLike(),
+                    weatherSnapshot.precipitationProbability(),
+                    weatherSnapshot.weatherType().name()
+            );
+        }
+    }
+}

--- a/src/test/java/com/yunhwan/wit/application/recommendation/RecommendationHomeServiceTest.java
+++ b/src/test/java/com/yunhwan/wit/application/recommendation/RecommendationHomeServiceTest.java
@@ -1,9 +1,11 @@
 package com.yunhwan.wit.application.recommendation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import com.yunhwan.wit.application.exception.WitException;
 import com.yunhwan.wit.application.google.GoogleIntegrationService;
 import com.yunhwan.wit.domain.model.CalendarEvent;
 import com.yunhwan.wit.domain.model.LocationResolvedBy;
@@ -49,6 +51,27 @@ class RecommendationHomeServiceTest {
         List<RecommendationResult> results = homeService.getHomeRecommendations();
 
         assertThat(results).containsExactly(recommendationResult);
+    }
+
+    @Test
+    void eventId로_단건_상세_추천을_조회한다() {
+        CalendarEvent event = calendarEvent("event-1");
+        RecommendationResult recommendationResult = recommendationResult(event);
+        given(googleIntegrationService.getUpcomingEvents()).willReturn(List.of(event));
+        given(recommendationService.recommend(event)).willReturn(recommendationResult);
+
+        RecommendationResult result = homeService.getEventRecommendation("event-1");
+
+        assertThat(result).isEqualTo(recommendationResult);
+    }
+
+    @Test
+    void eventId가_없으면_404_예외를_반환한다() {
+        given(googleIntegrationService.getUpcomingEvents()).willReturn(List.of(calendarEvent("event-1")));
+
+        assertThatThrownBy(() -> homeService.getEventRecommendation("event-404"))
+                .isInstanceOf(WitException.class)
+                .hasMessage("eventId에 해당하는 추천 대상이 없습니다. eventId=event-404");
     }
 
     private CalendarEvent calendarEvent(String eventId) {

--- a/src/test/java/com/yunhwan/wit/presentation/api/integration/GoogleIntegrationControllerTest.java
+++ b/src/test/java/com/yunhwan/wit/presentation/api/integration/GoogleIntegrationControllerTest.java
@@ -3,6 +3,7 @@ package com.yunhwan.wit.presentation.api.integration;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,16 +61,26 @@ class GoogleIntegrationControllerTest {
                         List.of()
                 ));
 
-        mockMvc.perform(get("/api/integrations/google/callback")
-                        .param("code", "oauth-code")
-                        .param("state", "oauth-state"))
+        mockMvc.perform(post("/api/integrations/google/callback")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "code": "oauth-code",
+                                  "state": "oauth-state"
+                                }
+                                """))
                 .andExpect(status().isOk());
     }
 
     @Test
     void callback_code가_없으면_400을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/integrations/google/callback")
-                        .param("state", "oauth-state"))
+        mockMvc.perform(post("/api/integrations/google/callback")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "state": "oauth-state"
+                                }
+                                """))
                 .andExpect(status().isBadRequest());
     }
 
@@ -78,9 +89,14 @@ class GoogleIntegrationControllerTest {
         given(googleIntegrationService.connect(any()))
                 .willThrow(new GoogleReauthenticationRequiredException("Google access token expired and re-authentication is required"));
 
-        mockMvc.perform(get("/api/integrations/google/callback")
-                        .param("code", "oauth-code")
-                        .param("state", "oauth-state"))
+        mockMvc.perform(post("/api/integrations/google/callback")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "code": "oauth-code",
+                                  "state": "oauth-state"
+                                }
+                                """))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("GOOGLE_401"))
                 .andExpect(jsonPath("$.message").value("Google access token expired and re-authentication is required"));
@@ -91,17 +107,38 @@ class GoogleIntegrationControllerTest {
         given(googleIntegrationService.connect(any()))
                 .willThrow(new GoogleIntegrationUnavailableException("Google integration is temporarily unavailable"));
 
-        mockMvc.perform(get("/api/integrations/google/callback")
-                        .param("code", "oauth-code")
-                        .param("state", "oauth-state"))
+        mockMvc.perform(post("/api/integrations/google/callback")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "code": "oauth-code",
+                                  "state": "oauth-state"
+                                }
+                                """))
                 .andExpect(status().isServiceUnavailable())
                 .andExpect(jsonPath("$.code").value("GOOGLE_503"))
                 .andExpect(jsonPath("$.message").value("Google integration is temporarily unavailable"));
     }
 
     @Test
-    void 다른_API는_인증없으면_401을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/recommendations/events/event-1"))
-                .andExpect(status().isUnauthorized());
+    void 기존_get_callback도_호환용으로_동작한다() throws Exception {
+        given(googleIntegrationService.connect(any()))
+                .willReturn(new GoogleConnectionResult(
+                        true,
+                        new GoogleIntegration(
+                                "default-user",
+                                "user@wit.local",
+                                "access-token",
+                                "refresh-token",
+                                LocalDateTime.of(2026, 4, 4, 10, 0),
+                                LocalDateTime.of(2026, 4, 4, 9, 0)
+                        ),
+                        List.of()
+                ));
+
+        mockMvc.perform(get("/api/integrations/google/callback")
+                        .param("code", "oauth-code")
+                        .param("state", "oauth-state"))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationControllerTest.java
+++ b/src/test/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.yunhwan.wit.application.recommendation.RecommendationHomeService;
 import com.yunhwan.wit.application.recommendation.RecommendationResult;
 import com.yunhwan.wit.application.recommendation.RecommendationWeatherSource;
+import com.yunhwan.wit.application.exception.ErrorCode;
+import com.yunhwan.wit.application.exception.WitException;
 import com.yunhwan.wit.domain.model.CalendarEvent;
 import com.yunhwan.wit.domain.model.LocationResolvedBy;
 import com.yunhwan.wit.domain.model.OutfitDecision;
@@ -48,15 +50,19 @@ class RecommendationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recommendations[0].eventId").value("event-1"))
                 .andExpect(jsonPath("$.recommendations[0].title").value("강남 회식"))
+                .andExpect(jsonPath("$.recommendations[0].startAt").value("2026-04-07T18:00:00"))
+                .andExpect(jsonPath("$.recommendations[0].endAt").value("2026-04-07T21:00:00"))
+                .andExpect(jsonPath("$.recommendations[0].location").value("서울특별시 강남구 테헤란로 1"))
                 .andExpect(jsonPath("$.recommendations[0].rawLocation").value("강남 목구멍"))
-                .andExpect(jsonPath("$.recommendations[0].resolvedLocation.displayLocation")
+                .andExpect(jsonPath("$.recommendations[0].locationResolution.displayLocation")
                         .value("서울특별시 강남구 테헤란로 1"))
-                .andExpect(jsonPath("$.recommendations[0].resolvedLocation.resolvedBy").value("GOOGLE_PLACES"))
+                .andExpect(jsonPath("$.recommendations[0].locationResolution.resolvedBy").value("GOOGLE_PLACES"))
                 .andExpect(jsonPath("$.recommendations[0].locationFallbackApplied").value(false))
                 .andExpect(jsonPath("$.recommendations[0].weatherSource").value("NORMAL"))
                 .andExpect(jsonPath("$.recommendations[0].needUmbrella").value(true))
                 .andExpect(jsonPath("$.recommendations[0].recommendedOutfitText").value("긴팔 + 가벼운 겉옷"))
-                .andExpect(jsonPath("$.recommendations[0].aiSummary").value("종료 시점 비 예보가 있어 우산과 긴팔 + 가벼운 겉옷이 필요합니다."))
+                .andExpect(jsonPath("$.recommendations[0].summary").value("종료 시점 비 예보가 있어 우산과 긴팔 + 가벼운 겉옷이 필요합니다."))
+                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value(nullValue()))
                 .andExpect(jsonPath("$.recommendations[0].weatherFallbackApplied").value(false))
                 .andExpect(jsonPath("$.recommendations[0].endWeather.weatherType").value("RAIN"));
     }
@@ -71,6 +77,7 @@ class RecommendationControllerTest {
                 .andExpect(jsonPath("$.recommendations[0].weatherFallbackApplied").value(true))
                 .andExpect(jsonPath("$.recommendations[0].locationFallbackApplied").value(true))
                 .andExpect(jsonPath("$.recommendations[0].weatherSource").value("SAFE_DEFAULT"))
+                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value("날씨 조회 실패로 안전 기본 추천을 반환했습니다."))
                 .andExpect(jsonPath("$.recommendations[0].currentWeather").value(nullValue()))
                 .andExpect(jsonPath("$.recommendations[0].startWeather").value(nullValue()))
                 .andExpect(jsonPath("$.recommendations[0].endWeather").value(nullValue()));
@@ -84,7 +91,36 @@ class RecommendationControllerTest {
         mockMvc.perform(get("/api/recommendations/home"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recommendations[0].weatherFallbackApplied").value(false))
-                .andExpect(jsonPath("$.recommendations[0].weatherSource").value("CACHE"));
+                .andExpect(jsonPath("$.recommendations[0].weatherSource").value("CACHE"))
+                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value("실시간 날씨 대신 최신 캐시 데이터를 사용했습니다."));
+    }
+
+    @Test
+    void 이벤트_상세_추천_응답은_단건_상세를_반환한다() throws Exception {
+        given(recommendationHomeService.getEventRecommendation("event-1"))
+                .willReturn(recommendationResult());
+
+        mockMvc.perform(get("/api/recommendations/events/event-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value("event-1"))
+                .andExpect(jsonPath("$.title").value("강남 회식"))
+                .andExpect(jsonPath("$.location").value("서울특별시 강남구 테헤란로 1"))
+                .andExpect(jsonPath("$.summary").value("종료 시점 비 예보가 있어 우산과 긴팔 + 가벼운 겉옷이 필요합니다."))
+                .andExpect(jsonPath("$.endWeather.weatherType").value("RAIN"));
+    }
+
+    @Test
+    void 이벤트_상세_추천_대상이_없으면_404를_반환한다() throws Exception {
+        given(recommendationHomeService.getEventRecommendation("event-404"))
+                .willThrow(new WitException(
+                        ErrorCode.RECOMMENDATION_EVENT_NOT_FOUND,
+                        "eventId에 해당하는 추천 대상이 없습니다. eventId=event-404"
+                ));
+
+        mockMvc.perform(get("/api/recommendations/events/event-404"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("RECOMMENDATION_404"))
+                .andExpect(jsonPath("$.message").value("eventId에 해당하는 추천 대상이 없습니다. eventId=event-404"));
     }
 
     private RecommendationResult recommendationResult() {


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

close #22 

## 작업 내용

- API 응답 스펙 정리 및 고정
- Swagger(OpenAPI) 기반 API 문서화 추가/보완

### 1. Google Integration API
- GET /api/integrations/google/login-url 응답 정의
- POST /api/integrations/google/callback 응답 정의

### 2. Recommendation API
- GET /api/recommendations/home 응답 스펙 정리
- GET /api/recommendations/events/{eventId} 상세 조회 API 추가 및 응답 정의

### 3. 응답 구조 정리
- 공통 응답 필드 정리 (title, location, needUmbrella, recommendedOutfitText, summary 등)
- 성공 / 실패 / fallback 상황별 응답 기준 명확화

### 4. Swagger 문서화
- 각 API별 request/response schema 정리
- iOS 연동 시 필드 의미를 바로 이해할 수 있도록 명세 보완

## 목적

- iOS 앱이 별도 해석 없이 바로 연동 가능한 API 계약 확정
- 구현과 문서 간 불일치 방지

## 참고

- 설계 문서 기준으로 AI 역할은 summary 및 location 해석에만 제한
- 우산/옷차림 판단 로직은 기존 규칙 엔진 유지

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [x] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
