### PR TITLE
Chore/ 추천 API 응답 및 예외 계약 고정

### DIFF
--- a/docs/api-spec-ko.md
+++ b/docs/api-spec-ko.md
@@ -39,6 +39,9 @@
 ### GET `/api/recommendations/home`
 
 - 응답: `recommendations[]`
+- 홈 API는 각 일정 추천을 독립적으로 생성한다.
+- 일부 일정에서 추천 생성에 실패하면 전체 요청을 실패시키지 않고 해당 항목만 응답 목록에서 제외할 수 있다.
+- 따라서 응답 목록은 조회된 전체 후보 일정 수와 항상 같다고 가정하지 않는다.
 - 각 항목 공통 핵심 필드:
   - `eventId`
   - `title`
@@ -84,6 +87,18 @@
 - `GOOGLE_401`: Google 재연동 필요
 - `GOOGLE_503`: Google 연동 장애
 - `COMMON_500`: 서버 내부 오류
+
+추천 API별 오류 노출:
+
+- `GET /api/recommendations/home`
+  - `401 GOOGLE_401`
+  - `503 GOOGLE_503`
+  - `500 COMMON_500`
+- `GET /api/recommendations/events/{eventId}`
+  - `404 RECOMMENDATION_404`
+  - `401 GOOGLE_401`
+  - `503 GOOGLE_503`
+  - `500 COMMON_500`
 
 ## 4. 현재 구현 기준 주의사항
 

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/HomeRecommendationResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/HomeRecommendationResponse.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 @Schema(description = "홈 추천 목록 응답")
 public record HomeRecommendationResponse(
-        @Schema(description = "추천 목록")
+        @Schema(
+                description = "추천 목록. 홈 API는 각 일정 추천을 독립적으로 생성하며, 일부 일정에서 추천 생성에 실패하면 해당 항목은 목록에서 제외될 수 있다."
+        )
         List<RecommendationResponse> recommendations
 ) {
 

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationController.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationController.java
@@ -40,6 +40,8 @@ public class RecommendationController {
                     content = @Content(schema = @Schema(implementation = HomeRecommendationResponse.class))),
             @ApiResponse(responseCode = "401", description = "Google 재연동 필요",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "추천 대상 일정 없음",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
             @ApiResponse(responseCode = "503", description = "Google 연동 장애",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationController.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationController.java
@@ -31,13 +31,18 @@ public class RecommendationController {
     }
 
     @GetMapping("/home")
-    @Operation(summary = "홈 추천 조회", description = "향후 일정 최대 3건에 대한 추천 목록을 반환한다.")
+    @Operation(
+            summary = "홈 추천 조회",
+            description = "향후 일정 최대 3건에 대한 추천 목록을 반환한다. 각 일정 추천은 독립적으로 생성되며 일부 일정에서 추천 생성에 실패하면 해당 항목은 응답 목록에서 제외될 수 있다."
+    )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공",
                     content = @Content(schema = @Schema(implementation = HomeRecommendationResponse.class))),
             @ApiResponse(responseCode = "401", description = "Google 재연동 필요",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
             @ApiResponse(responseCode = "503", description = "Google 연동 장애",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public HomeRecommendationResponse getHomeRecommendations() {
@@ -58,6 +63,8 @@ public class RecommendationController {
             @ApiResponse(responseCode = "401", description = "Google 재연동 필요",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
             @ApiResponse(responseCode = "503", description = "Google 연동 장애",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public RecommendationResponse getEventRecommendation(@PathVariable String eventId) {


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

close #46 

## 개요

Step 3 [API] 추천 API 응답 / 예외 계약 고정 작업으로,
현재 구현된 동작을 기준으로 API 계약을 명시적으로 정리했습니다.

## 변경 내용

### 1. /api/recommendations/home 부분 실패 계약 명시
- 개별 추천 생성 중 실패가 발생할 경우 해당 항목이 목록에서 제외될 수 있음을 명시
- 클라이언트가 응답 목록 길이를 고정된 개수로 가정하지 않도록 계약 정의

### 2. 500 COMMON_500 노출 추가
- 추천 API 문서 및 OpenAPI에 500 COMMON_500 응답 추가
- GlobalExceptionHandler와 컨트롤러 선언 간 불일치 해소

### 3. API 계약 정렬
- 응답 DTO 필드 의미를 문서와 일치하도록 재확인
- degraded / fallback 관련 필드 의미 명확화
  - locationFallbackApplied
  - weatherFallbackApplied
  - weatherSource
  - fallbackNotice

## 결과

- 추천 API 응답 및 예외 계약이 현재 구현과 일관되게 정리됨
- 부분 실패 및 내부 오류 노출 기준이 명확해짐
- 클라이언트가 해석해야 할 응답 의미가 계약 수준에서 고정됨

## 범위

- 문서 / OpenAPI / 컨트롤러 선언 정렬
- 실제 추천 로직, fallback 정책, DTO 구조 변경 없음

## 확인 방법

- OpenAPI 문서에서 500 COMMON_500 노출 여부 확인
- /api/recommendations/home 응답 계약 설명 확인
- 기존 API 응답 및 동작 변화 없음 확인

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [ ] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
