### PR TITLE
Test/ rule engine 회귀 테스트 보강 및 경계/우선순위 케이스 추가

### DIFF
--- a/src/test/java/com/yunhwan/wit/domain/rule/OutfitRuleEngineTest.java
+++ b/src/test/java/com/yunhwan/wit/domain/rule/OutfitRuleEngineTest.java
@@ -131,7 +131,7 @@ class OutfitRuleEngineTest {
         assertThat(decision.needUmbrella()).isTrue();
         assertThat(decision.recommendedOutfitLevel()).isEqualTo(RecommendedOutfitLevel.LONG_SLEEVE);
         assertThat(decision.outfitReason()).contains("3도 이상 내려가");
-        assertThat(decision.temperatureGap()).isZero();
+        assertThat(decision.temperatureGap()).isNull();
         assertThat(decision.weatherChangeSummary()).contains("기온이 내려갑니다");
     }
 
@@ -162,6 +162,19 @@ class OutfitRuleEngineTest {
     }
 
     @Test
+    void 저온과_비_보정은_13도에서는_적용되지_않는다() {
+        OutfitDecision decision = decide(
+                snapshot(14, 14, 10, WeatherType.CLEAR),
+                snapshot(14, 14, 10, WeatherType.CLEAR),
+                snapshot(13, 13, 40, WeatherType.RAIN)
+        );
+
+        assertThat(decision.recommendedOutfitLevel()).isEqualTo(RecommendedOutfitLevel.LONG_SLEEVE_WITH_LIGHT_OUTER);
+        assertThat(decision.recommendedOutfitText()).isEqualTo("긴팔 + 가벼운 겉옷");
+        assertThat(decision.outfitReason()).contains("종료 시점 체감온도 기준");
+    }
+
+    @Test
     void 보정조건이_없으면_기본_옷차림을_유지한다() {
         OutfitDecision decision = decide(
                 snapshot(21, 21, 10, WeatherType.CLEAR),
@@ -185,6 +198,44 @@ class OutfitRuleEngineTest {
 
         assertThat(decision.recommendedOutfitLevel()).isEqualTo(RecommendedOutfitLevel.LONG_SLEEVE);
         assertThat(decision.recommendedOutfitText()).isEqualTo("긴팔");
+    }
+
+    @Test
+    void 여러_보정조건이_동시에_성립하면_current기준_보정이유를_우선한다() {
+        OutfitDecision decision = decide(
+                snapshot(25, 25, 10, WeatherType.CLEAR),
+                snapshot(23, 23, 10, WeatherType.CLEAR),
+                snapshot(12, 12, 70, WeatherType.RAIN)
+        );
+
+        assertThat(decision.recommendedOutfitLevel()).isEqualTo(RecommendedOutfitLevel.HEAVY_OUTER);
+        assertThat(decision.outfitReason()).contains("현재보다 4도 이상 낮아");
+    }
+
+    @Test
+    void 보정조건이_있어도_두꺼운겉옷_이상으로는_올라가지_않는다() {
+        OutfitDecision decision = decide(
+                snapshot(18, 18, 10, WeatherType.CLEAR),
+                snapshot(15, 15, 10, WeatherType.CLEAR),
+                snapshot(9, 9, 70, WeatherType.RAIN)
+        );
+
+        assertThat(decision.recommendedOutfitLevel()).isEqualTo(RecommendedOutfitLevel.HEAVY_OUTER);
+        assertThat(decision.recommendedOutfitText()).isEqualTo("두꺼운 겉옷");
+        assertThat(decision.outfitReason()).contains("현재보다 4도 이상 낮아");
+    }
+
+    @Test
+    void 비와_강수확률이_동시에_성립하면_우산이유는_비예보를_우선한다() {
+        OutfitDecision decision = decide(
+                snapshot(22, 22, 10, WeatherType.CLEAR),
+                snapshot(21, 21, 10, WeatherType.CLEAR),
+                snapshot(20, 20, 80, WeatherType.RAIN)
+        );
+
+        assertThat(decision.needUmbrella()).isTrue();
+        assertThat(decision.umbrellaReason()).contains("비 예보");
+        assertThat(decision.umbrellaReason()).doesNotContain("50%");
     }
 
     @Test

--- a/src/test/java/com/yunhwan/wit/domain/rule/OutfitRuleEngineTest.java
+++ b/src/test/java/com/yunhwan/wit/domain/rule/OutfitRuleEngineTest.java
@@ -210,6 +210,8 @@ class OutfitRuleEngineTest {
 
         assertThat(decision.recommendedOutfitLevel()).isEqualTo(RecommendedOutfitLevel.HEAVY_OUTER);
         assertThat(decision.outfitReason()).contains("현재보다 4도 이상 낮아");
+        assertThat(decision.outfitReason()).doesNotContain("3도 이상 내려가");
+        assertThat(decision.outfitReason()).doesNotContain("낮은 체감온도와 비");
     }
 
     @Test


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

close #47 

## 개요

Rule Engine의 핵심 판단 로직이 이후 변경으로 인해 깨지지 않도록
경계값, 우선순위, 포화 상태에 대한 회귀 테스트를 보강했습니다.

## 변경 내용

- OutfitRuleEngine 테스트 보강
  - 저온 + 비 보정 경계값 테스트 추가 (12도 / 13도)
  - 보정 조건 동시 성립 시 reason 우선순위 검증
  - HEAVY_OUTER 포화 상태 유지 검증 (추가 상승 방지)
  - RAIN vs 강수확률 동시 성립 시 우산 reason 우선순위 검증

## 목적

- 규칙 엔진의 핵심 판단 기준을 테스트로 고정
- 경계값 및 조건 우선순위 변경으로 인한 회귀 방지
- 최소 범위 내에서 안정성 확보

## 범위

- Rule Engine 단위 테스트만 포함
- RecommendationService, API, 외부 연동 관련 테스트는 제외

## 검증 방법

- 테스트 전체 실행
- 추가된 테스트 케이스 정상 통과 확인

## 비고

- Step 4 범위 내 최소 회귀 테스트 보강만 수행
- 추가 확장은 Step 5 (통합 테스트)에서 진행 예정

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [x] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
