### PR TITLE
Docs/ 캐시 정책 및 응답 계약 정리

### DIFF
--- a/docs/api-spec-ko.md
+++ b/docs/api-spec-ko.md
@@ -14,11 +14,14 @@
 - `locationFallbackApplied=true`면 일정 위치 해석에 실패해 현재 위치 기준으로 추천한 경우다.
 - 이 경우 해당 응답은 목적지 기반 추천이 아니며, `location`도 현재 위치 표시값이다.
 - 이 경우 `originalLocationResolution`에 fallback 이전의 원래 `FAILED` 위치 해석 결과를 함께 담는다.
-- `weatherFallbackApplied=true`면 날씨 조회 실패로 safe default 추천을 반환한 경우다.
-- `weatherSource=CACHE`면 실시간 대신 최신 캐시 날씨를 사용한 경우다.
+- `weatherFallbackApplied=true`면 날씨 조회 실패 후 latest cache도 없어 safe default 추천을 반환한 경우다.
+- `weatherSource=NORMAL`이면 응답 생성에 사용된 날씨 입력이 정상 조회 기준이다.
+- `weatherSource=CACHE`면 응답 생성에 사용된 날씨 입력 중 하나 이상이 캐시 데이터다. exact cache hit와 API 실패 후 latest cache fallback을 모두 포함한다.
+- `weatherSource=SAFE_DEFAULT`면 start/end 기준 날씨를 확보하지 못해 safe default 추천을 사용한 경우다.
 - `fallbackNotice`는 fallback 의미를 바로 이해할 수 있게 추가한 사용자용 안내 문구다.
 - fallback/degraded-state 설명의 1차 채널은 `fallbackNotice`, `locationFallbackApplied`, `weatherFallbackApplied`, `weatherSource` 같은 구조화 필드다.
 - `summary`는 fallback/degraded-state를 주된 방식으로 설명하지 않으며, fallback 여부 판단은 반드시 구조화 필드와 `fallbackNotice`로 한다.
+- 현재 MVP는 location/recommendation cache hit 여부를 별도 응답 필드로 노출하지 않는다. 두 캐시는 내부 최적화이며 검증은 테스트로 수행한다.
 
 ## 2. 엔드포인트
 
@@ -104,9 +107,10 @@
 
 - `summary`는 AI summary 실패 시 deterministic fallback 문장으로 대체될 수 있다.
 - `summary`는 recommendation content 전용이며, fallback/degraded-state를 대표하는 필드로 해석하지 않는다.
-- `weatherFallbackApplied=true`면 `currentWeather`, `startWeather`, `endWeather`는 `null`이다.
+- `weatherFallbackApplied=true`면 `weatherSource=SAFE_DEFAULT`이며 `currentWeather`, `startWeather`, `endWeather`는 `null`이다.
 - `weatherFallbackApplied=false`여도 `currentWeather`는 `null`일 수 있다. 이 경우 `startWeather`와 `endWeather`가 있으면 추천은 계속 진행되고 current 기반 보정만 생략된다.
 - 실제 현재 위치가 없으면 `currentWeather`는 목적지 날씨로 대체하지 않고 `null`로 유지한다.
+- `weatherSource=CACHE`일 때 `fallbackNotice`는 "실시간 호출 대신 캐시된 날씨 데이터를 사용했습니다."다.
 - `weatherSource`는 `NORMAL`, `CACHE`, `SAFE_DEFAULT` 중 하나다.
 - `POST /api/integrations/google/callback`이 iOS용 기준 엔드포인트다.
 - 기존 GET callback도 호환용으로 유지되지만, 신규 클라이언트 계약은 POST 기준으로 본다.

--- a/docs/api-spec-ko.md
+++ b/docs/api-spec-ko.md
@@ -21,6 +21,7 @@
 - `fallbackNotice`는 fallback 의미를 바로 이해할 수 있게 추가한 사용자용 안내 문구다.
 - fallback/degraded-state 설명의 1차 채널은 `fallbackNotice`, `locationFallbackApplied`, `weatherFallbackApplied`, `weatherSource` 같은 구조화 필드다.
 - `summary`는 fallback/degraded-state를 주된 방식으로 설명하지 않으며, fallback 여부 판단은 반드시 구조화 필드와 `fallbackNotice`로 한다.
+- API 응답으로 구분 가능한 cache usage는 weather cache에 한정한다. 이 구분은 `weatherSource`와 `weatherFallbackApplied`로 표현한다.
 - 현재 MVP는 location/recommendation cache hit 여부를 별도 응답 필드로 노출하지 않는다. 두 캐시는 내부 최적화이며 검증은 테스트로 수행한다.
 
 ## 2. 엔드포인트

--- a/docs/design-overview-ko-v2.md
+++ b/docs/design-overview-ko-v2.md
@@ -361,7 +361,11 @@ GET  /api/recommendations/events/{eventId}
 
 ```
 현재 구현:
-- single configured TTL 사용
+- 목적: 반복 위치 해석 시 Google Places/AI 호출 비용 절감
+- key: raw location 입력을 trim + lower-case 한 값
+- miss 시 rule -> Google Places -> AI fallback 순서로 해석
+- `FAILED` 결과도 cache 저장 후 recommendation 단계 current location fallback으로 연결
+- 기본 TTL: 24h
 
 향후 운영 옵션:
 - 상태별 TTL 차등 적용 가능
@@ -373,7 +377,12 @@ GET  /api/recommendations/events/{eventId}
 
 ```
 현재 구현:
-- single configured TTL 사용
+- current key: lat/lon + hour-bucket(now)
+- forecast key: lat/lon + targetTime
+- latest fallback key: latest:current|forecast + lat/lon
+- 정상 조회 실패 시 latest cache를 먼저 사용하고, start/end 확보 실패 시 safe default로 내린다
+- `weatherSource=CACHE`는 exact cache hit와 latest cache fallback을 함께 뜻한다
+- 기본 TTL: 1h
 
 향후 운영 옵션:
 - 현재/예보 TTL 분리 가능
@@ -385,7 +394,10 @@ GET  /api/recommendations/events/{eventId}
 
 ```
 현재 구현:
-- single configured TTL 사용
+- key: eventId + 30분 요청 버킷 + startAt + endAt + normalized rawLocation
+- cache hit 시 저장된 최종 RecommendationResult를 그대로 반환
+- 기본 TTL: 30m
+- 별도 API 필드로 recommendation cache hit/miss를 노출하지 않음
 ```
 
 ---

--- a/docs/design-overview-ko-v2.md
+++ b/docs/design-overview-ko-v2.md
@@ -382,6 +382,7 @@ GET  /api/recommendations/events/{eventId}
 - latest fallback key: latest:current|forecast + lat/lon
 - 정상 조회 실패 시 latest cache를 먼저 사용하고, start/end 확보 실패 시 safe default로 내린다
 - `weatherSource=CACHE`는 exact cache hit와 latest cache fallback을 함께 뜻한다
+- weather cache usage만 API 응답(`weatherSource`, `weatherFallbackApplied`)으로 구분한다
 - 기본 TTL: 1h
 
 향후 운영 옵션:

--- a/docs/integration-test.md
+++ b/docs/integration-test.md
@@ -110,6 +110,19 @@
 
 또한 AI fallback wiring은 별도 Spring 기반 테스트에서 확인한다.
 
+cache 검증 기준:
+
+- API 응답 검증
+  - `weatherSource=NORMAL|CACHE|SAFE_DEFAULT`
+  - `weatherFallbackApplied`
+  - `fallbackNotice`
+  - safe default 시 weather snapshot 3종이 `null`
+- 단위 테스트 검증
+  - location cache: key 정규화, TTL, hit/miss, `FAILED` 결과 저장
+  - weather cache: current/forecast/latest key, TTL, latest fallback 경로
+  - recommendation cache: key, TTL, hit 시 전체 흐름 미재실행, miss 후 저장
+- 현재 MVP는 location/recommendation cache hit 여부를 API 필드로 직접 노출하지 않는다
+
 ---
 
 ## 6. 테스트 구조

--- a/docs/integration-test.md
+++ b/docs/integration-test.md
@@ -113,6 +113,7 @@
 cache 검증 기준:
 
 - API 응답 검증
+  - weather cache만 응답 필드로 검증한다
   - `weatherSource=NORMAL|CACHE|SAFE_DEFAULT`
   - `weatherFallbackApplied`
   - `fallbackNotice`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -72,6 +72,7 @@
 - fallback/degraded-state 설명은 `fallbackNotice`와 구조화 상태 필드(`locationFallbackApplied`, `weatherFallbackApplied`, `weatherSource`)가 담당한다
 - `summary`는 fallback/degraded-state를 전달하는 주 채널로 사용하지 않는다
 - 클라이언트는 fallback 여부를 `summary`가 아니라 구조화 필드와 `fallbackNotice`로 판단해야 한다
+- API 응답에서 cache usage를 구조화 필드로 노출하는 대상은 weather cache뿐이다
 
 ### Location Failure
 - FAILED면 current location 기준으로 fallback

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -81,7 +81,8 @@
 - 이 경우 메인 `locationResolution`은 fallback에 실제 사용된 위치를 나타내고, `originalLocationResolution`은 원래의 `FAILED` 해석 결과를 보존한다
 
 ### Weather Failure
-- fallback to latest cached data
+- weather path order: exact cache hit or 정상 조회 -> API failure 시 latest cache fallback -> safe default
+- `weatherSource=CACHE`는 exact cache hit와 latest cache fallback을 모두 포함한다
 - start 또는 end weather가 없으면 → safe default outfit
 - start / end weather가 있으면 recommendation은 계속 진행한다
 - current weather만 없으면 current 기반 보정만 생략한다
@@ -105,15 +106,23 @@
 ## Cache Strategy (for later stage)
 
 ### Location Cache
-- key: location_name
-- 현재 구현은 single configured TTL 사용
+- 목적: 반복 location 해석 시 Google Places/AI 호출 비용 절감
+- key: raw location 입력을 `trim + lower-case`한 값
+- miss 시 resolver 순서: rule -> Google Places -> AI fallback
+- resolver 최종 결과가 `FAILED`여도 cache 저장 대상이다
+- recommendation 단계에서 `FAILED`면 current location fallback으로 이어진다
+- 현재 구현 기본 TTL: 24h
 - 상태별 TTL 차등 적용은 향후 운영 옵션
 
 ### Weather Cache
-- key: lat/lon + time
-- 현재 구현은 single configured TTL 사용
+- current key: `lat/lon + hour-bucket(now)`
+- forecast key: `lat/lon + targetTime`
+- latest fallback key: `latest:current|forecast + lat/lon`
+- 현재 구현 기본 TTL: 1h
 - 현재/예보 TTL 분리는 향후 운영 옵션
 
 ### Recommendation Cache
-- key: event + time + location
-- 현재 구현은 single configured TTL 사용
+- key: `eventId + 30분 요청 버킷 + startAt + endAt + normalized rawLocation`
+- cache hit 시 저장된 최종 `RecommendationResult`를 그대로 반환한다
+- 현재 구현 기본 TTL: 30m
+- recommendation cache hit/miss는 현재 MVP에서 별도 API 필드로 노출하지 않는다

--- a/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationResponse.java
+++ b/src/main/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationResponse.java
@@ -89,7 +89,7 @@ public record RecommendationResponse(
             return "날씨 조회 실패로 안전 기본 추천을 반환했습니다.";
         }
         if ("CACHE".equals(result.weatherSource().name())) {
-            return "실시간 날씨 대신 최신 캐시 데이터를 사용했습니다.";
+            return "실시간 호출 대신 캐시된 날씨 데이터를 사용했습니다.";
         }
         if (result.locationFallbackApplied()) {
             return "일정 위치 해석에 실패해 현재 위치 기준으로 추천했습니다.";

--- a/src/test/java/com/yunhwan/wit/application/recommendation/RecommendationServiceTest.java
+++ b/src/test/java/com/yunhwan/wit/application/recommendation/RecommendationServiceTest.java
@@ -9,6 +9,7 @@ import com.yunhwan.wit.application.summary.SummaryGenerator;
 import com.yunhwan.wit.application.weather.CachingWeatherClient;
 import com.yunhwan.wit.application.weather.WeatherClient;
 import com.yunhwan.wit.application.weather.WeatherCache;
+import com.yunhwan.wit.application.weather.WeatherForecastSnapshots;
 import com.yunhwan.wit.domain.model.CalendarEvent;
 import com.yunhwan.wit.domain.model.LocationResolvedBy;
 import com.yunhwan.wit.domain.model.LocationResolutionStatus;
@@ -280,6 +281,59 @@ class RecommendationServiceTest {
         assertThat(result.endWeather()).isNotNull();
         assertThat(ruleEngine.called).isTrue();
         assertThat(fallbackDecisionProvider.called).isFalse();
+    }
+
+    @Test
+    void 일부_날씨만_캐시를_사용해도_weather_source는_CACHE다() {
+        ResolvedLocation currentLocation = currentLocation();
+        ResolvedLocation eventLocation = eventLocation();
+        WeatherSnapshot currentWeather = snapshot(currentLocation, currentTime, 20, 20, 10, WeatherType.CLEAR);
+        WeatherSnapshot startWeather = snapshot(eventLocation, calendarEvent.startAt(), 19, 19, 20, WeatherType.CLOUDY);
+        WeatherSnapshot endWeather = snapshot(eventLocation, calendarEvent.endAt(), 16, 16, 70, WeatherType.RAIN);
+        WeatherClient weatherClient = new WeatherClient() {
+            @Override
+            public WeatherSnapshot fetchCurrentWeather(ResolvedLocation location) {
+                return currentWeather;
+            }
+
+            @Override
+            public WeatherSnapshot fetchWeatherAt(ResolvedLocation location, LocalDateTime targetTime) {
+                return targetTime.equals(calendarEvent.startAt()) ? startWeather : endWeather;
+            }
+
+            @Override
+            public CurrentWeatherResult fetchCurrentWeatherResult(ResolvedLocation location) {
+                return new CurrentWeatherResult(currentWeather, WeatherFetchSource.CACHE);
+            }
+
+            @Override
+            public WeatherRangeResult fetchWeatherRangeResult(
+                    ResolvedLocation location,
+                    LocalDateTime startTime,
+                    LocalDateTime endTime
+            ) {
+                return new WeatherRangeResult(
+                        new WeatherForecastSnapshots(startWeather, endWeather),
+                        WeatherFetchSource.NORMAL
+                );
+            }
+        };
+
+        RecommendationService recommendationService = new RecommendationService(
+                rawLocation -> eventLocation,
+                () -> currentLocation,
+                weatherClient,
+                new OutfitRuleEngine(),
+                new WeatherFailureFallbackDecisionProvider(),
+                new StubSummaryGenerator(),
+                new InMemoryRecommendationCache(),
+                clock
+        );
+
+        RecommendationResult result = recommendationService.recommend(calendarEvent);
+
+        assertThat(result.weatherFallbackApplied()).isFalse();
+        assertThat(result.weatherSource()).isEqualTo(RecommendationWeatherSource.CACHE);
     }
 
     @Test

--- a/src/test/java/com/yunhwan/wit/infrastructure/location/RedisLocationResolutionCacheTest.java
+++ b/src/test/java/com/yunhwan/wit/infrastructure/location/RedisLocationResolutionCacheTest.java
@@ -1,0 +1,74 @@
+package com.yunhwan.wit.infrastructure.location;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yunhwan.wit.domain.model.LocationResolvedBy;
+import com.yunhwan.wit.domain.model.ResolvedLocation;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class RedisLocationResolutionCacheTest {
+
+    @Test
+    void location결과를_기본TTL로_저장한다() throws Exception {
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+        RedisLocationResolutionCache cache = new RedisLocationResolutionCache(
+                redisTemplate,
+                objectMapper,
+                new LocationCacheProperties(Duration.ofHours(24))
+        );
+
+        cache.put("강남 회식", resolvedLocation());
+
+        verify(valueOperations).set(
+                eq("location:resolution:강남 회식"),
+                eq(objectMapper.writeValueAsString(resolvedLocation())),
+                eq(Duration.ofHours(24))
+        );
+    }
+
+    @Test
+    void location조회키는_trim과_lower_case로_정규화한다() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        String serialized = objectMapper.writeValueAsString(resolvedLocation());
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("location:resolution:gangnam station")).thenReturn(serialized);
+
+        RedisLocationResolutionCache cache = new RedisLocationResolutionCache(
+                redisTemplate,
+                objectMapper,
+                new LocationCacheProperties(Duration.ofHours(24))
+        );
+
+        ResolvedLocation result = cache.find("  Gangnam Station  ").orElseThrow();
+
+        assertThat(result).isEqualTo(resolvedLocation());
+    }
+
+    private ResolvedLocation resolvedLocation() {
+        return ResolvedLocation.resolved(
+                "Gangnam Station",
+                "gangnam station",
+                "서울특별시 강남구",
+                37.4979,
+                127.0276,
+                0.9,
+                LocationResolvedBy.GOOGLE_PLACES
+        );
+    }
+}

--- a/src/test/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationApiIntegrationTest.java
+++ b/src/test/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationApiIntegrationTest.java
@@ -274,7 +274,7 @@ class RecommendationApiIntegrationTest extends IntegrationTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recommendations[0].weatherFallbackApplied").value(false))
                 .andExpect(jsonPath("$.recommendations[0].weatherSource").value("CACHE"))
-                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value("실시간 날씨 대신 최신 캐시 데이터를 사용했습니다."));
+                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value("실시간 호출 대신 캐시된 날씨 데이터를 사용했습니다."));
     }
 
     @Test

--- a/src/test/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationControllerTest.java
+++ b/src/test/java/com/yunhwan/wit/presentation/api/recommendation/RecommendationControllerTest.java
@@ -98,7 +98,7 @@ class RecommendationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recommendations[0].weatherFallbackApplied").value(false))
                 .andExpect(jsonPath("$.recommendations[0].weatherSource").value("CACHE"))
-                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value("실시간 날씨 대신 최신 캐시 데이터를 사용했습니다."));
+                .andExpect(jsonPath("$.recommendations[0].fallbackNotice").value("실시간 호출 대신 캐시된 날씨 데이터를 사용했습니다."));
     }
 
     @Test


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] ⚰️ Maintain (keep in good condition or in working)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

close #52 

## 개요

Step 9(Cache policy) 범위에 따라 location, weather, recommendation 캐시 정책을 문서 기준으로 고정하고,
API 응답 계약 및 테스트 검증 기준을 일관되게 정리했습니다.

## 작업 내용

- 캐시 정책 정리
  - location / weather / recommendation cache key 및 TTL 기준 명문화
- weather fallback 흐름 고정
  - API 실패 → latest cache → safe default
- 응답 계약 정리
  - weather cache만 API 응답(weatherSource)으로 노출
  - location / recommendation cache는 API 비노출, 테스트 검증 전용으로 유지
- 문서 간 정책 일관성 정리
  - api-spec / rules / design-overview / integration-test 기준 통일

## 결과

- 캐시 정책이 key / TTL / fallback 기준까지 일관되게 문서화됨
- API 응답과 테스트 기준이 명확히 분리됨
  - weather cache: 응답 기반 검증
  - location / recommendation cache: 테스트 기반 검증
- 기존 도메인 책임 유지
  - rule engine 및 AI 역할 변경 없음

## 영향 범위

- 문서 수정
- 테스트 검증 기준 정리
- 코드 동작 변경 없음

<!-- 이슈를 해결한 코드에 대해 설명해주세요. -->

### 📝 Checklist

<!-- 테스트 코드 구성이 가능하다면 포함해주세요. -->
<!-- 문서화가 따로 필요 없는 부분이라면 해당 항목을 삭제해주세요. -->

- [x] 🔴 Human eyes (no test)
- [ ] 🟡 swagger or Smoke test
- [x] 🟢 unit test or CI test

### 📸 Log/Screenshot

<!-- 로그나 테스트 스크린샷이 있을 경우 첨부해주세요. -->

🌱 before

🏡 after
